### PR TITLE
Fixing minor indentation error for new date format

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,8 +12,8 @@ importer:
 logging:
   level:
     ROOT: ERROR
-    pattern:
-      console: "%clr(%d{dd-MM-yyyy HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr([%35.35t]){faint} %clr(%-28.28logger{28}){cyan} %clr(:){faint}%X{BUSINESS-LOG} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"
+  pattern:
+    console: "%clr(%d{dd-MM-yyyy HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr([%35.35t]){faint} %clr(%-28.28logger{28}){cyan} %clr(:){faint}%X{BUSINESS-LOG} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"
 
 
 reporting:


### PR DESCRIPTION
This PR is to fix minor error we are getting. 

`Picked up JAVA_TOOL_OPTIONS: 
03-08-2022 07:57:57.697 [main] ERROR org.springframework.boot.SpringApplication.reportFailure - Application run failed
org.springframework.boot.context.properties.bind.BindException: Failed to bind properties under 'logging.level.pattern.console' to org.springframework.boot.logging.LogLevel`

@avikganguly01 : Please review