### PR TITLE
[PHEE-384] Resolved masking for payer and payee object and array types

### DIFF
--- a/src/main/java/org/mifos/phee/kafkastreamer/importer/KafkaVariables.java
+++ b/src/main/java/org/mifos/phee/kafkastreamer/importer/KafkaVariables.java
@@ -14,4 +14,5 @@ public class KafkaVariables {
     public static final String PARTY_IDENTIFIER = "partyIdentifier";
     public static final String DEBIT_PARTY = "debitParty";
     public static final String CREDIT_PARTY = "creditParty";
+    public static final String PARTY_ID_IDENTIFIER = "partyIdIdentifier";
 }

--- a/src/main/java/org/mifos/phee/kafkastreamer/importer/service/MaskingServiceImpl.java
+++ b/src/main/java/org/mifos/phee/kafkastreamer/importer/service/MaskingServiceImpl.java
@@ -70,7 +70,6 @@ public class MaskingServiceImpl implements MaskingService {
 
                     payerObject.put(KafkaVariables.PARTY_ID_IDENTIFIER, payerPartyIdentifier);
                     payeeObject.put(KafkaVariables.PARTY_ID_IDENTIFIER, payeePartyIdentifier);
-
                 } else if (payerValue instanceof JSONObject) {
                     JSONObject payerObject = (JSONObject) payerValue;
                     JSONObject payeeObject = (JSONObject) payeeValue;

--- a/src/main/java/org/mifos/phee/kafkastreamer/importer/service/MaskingServiceImpl.java
+++ b/src/main/java/org/mifos/phee/kafkastreamer/importer/service/MaskingServiceImpl.java
@@ -4,6 +4,8 @@ import static org.apache.commons.text.StringEscapeUtils.unescapeJava;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.mifos.phee.kafkastreamer.importer.KafkaVariables;
 import org.mifos.phee.kafkastreamer.importer.utils.AesUtil;
@@ -48,20 +50,44 @@ public class MaskingServiceImpl implements MaskingService {
             if(AesUtil.checkForMaskingFields(channelRequest,fieldsRequiredMasking)){
                 return rawData;
             }
+            String payerPartyIdentifier = "", payeePartyIdentifier = "";
 
-            String payerPartyIdentifier = channelRequest.getJSONObject(KafkaVariables.PAYER).getJSONObject(KafkaVariables.PARTY_ID_INFO)
-                    .getString(KafkaVariables.PARTY_IDENTIFIER);
-            String payeePartyIdentifier = channelRequest.getJSONObject(KafkaVariables.PAYEE).getJSONObject(KafkaVariables.PARTY_ID_INFO)
-                    .getString(KafkaVariables.PARTY_IDENTIFIER);
+            if (channelRequest.has("payer")) {
+                Object payerValue = channelRequest.get("payer");
+                Object payeeValue = channelRequest.get("payee");
 
-            payerPartyIdentifier = encryptData(payerPartyIdentifier);
-            payeePartyIdentifier = encryptData(payeePartyIdentifier);
+                if (payerValue instanceof JSONArray) {
+                    JSONArray payerArray = (JSONArray) payerValue;
+                    JSONArray payeeArray = (JSONArray) payeeValue;
 
-            channelRequest.getJSONObject(KafkaVariables.PAYER).getJSONObject(KafkaVariables.PARTY_ID_INFO)
-                    .put(KafkaVariables.PARTY_IDENTIFIER, payerPartyIdentifier);
-            channelRequest.getJSONObject(KafkaVariables.PAYEE).getJSONObject(KafkaVariables.PARTY_ID_INFO)
-                    .put(KafkaVariables.PARTY_IDENTIFIER, payeePartyIdentifier);
+                    JSONObject payerObject = payerArray.getJSONObject(0);
+                    payerPartyIdentifier = payerObject.getString(KafkaVariables.PARTY_IDENTIFIER);
+                    JSONObject payeeObject = payeeArray.getJSONObject(0);
+                    payeePartyIdentifier = payeeObject.getString(KafkaVariables.PARTY_IDENTIFIER);
 
+                    payerPartyIdentifier = encryptData(payerPartyIdentifier);
+                    payeePartyIdentifier = encryptData(payeePartyIdentifier);
+
+                    payerObject.put(KafkaVariables.PARTY_IDENTIFIER, payerPartyIdentifier);
+                    payeeObject.put(KafkaVariables.PARTY_IDENTIFIER, payeePartyIdentifier);
+
+                } else if (payerValue instanceof JSONObject) {
+                    JSONObject payerObject = (JSONObject) payerValue;
+                    JSONObject payeeObject = (JSONObject) payeeValue;
+                    payerPartyIdentifier = payerObject.getJSONObject(KafkaVariables.PARTY_ID_INFO)
+                            .getString(KafkaVariables.PARTY_IDENTIFIER);
+                    payeePartyIdentifier = payeeObject.getJSONObject(KafkaVariables.PARTY_ID_INFO)
+                            .getString(KafkaVariables.PARTY_IDENTIFIER);
+                    payerPartyIdentifier = encryptData(payerPartyIdentifier);
+                    payeePartyIdentifier = encryptData(payeePartyIdentifier);
+
+                    channelRequest.getJSONObject(KafkaVariables.PAYER).getJSONObject(KafkaVariables.PARTY_ID_INFO)
+                            .put(KafkaVariables.PARTY_IDENTIFIER, payerPartyIdentifier);
+                    channelRequest.getJSONObject(KafkaVariables.PAYEE).getJSONObject(KafkaVariables.PARTY_ID_INFO)
+                            .put(KafkaVariables.PARTY_IDENTIFIER, payeePartyIdentifier);
+                }
+
+            }
             value.put(KafkaVariables.VALUE, channelRequest.toString());
         } else if (name.equalsIgnoreCase(KafkaVariables.CHANNEL_GSMA_REQUEST)) {
             log.debug("Inside CHANNEL_GSMA_REQUEST condition");

--- a/src/main/java/org/mifos/phee/kafkastreamer/importer/service/MaskingServiceImpl.java
+++ b/src/main/java/org/mifos/phee/kafkastreamer/importer/service/MaskingServiceImpl.java
@@ -61,15 +61,15 @@ public class MaskingServiceImpl implements MaskingService {
                     JSONArray payeeArray = (JSONArray) payeeValue;
 
                     JSONObject payerObject = payerArray.getJSONObject(0);
-                    payerPartyIdentifier = payerObject.getString(KafkaVariables.PARTY_IDENTIFIER);
+                    payerPartyIdentifier = payerObject.getString(KafkaVariables.PARTY_ID_IDENTIFIER);
                     JSONObject payeeObject = payeeArray.getJSONObject(0);
-                    payeePartyIdentifier = payeeObject.getString(KafkaVariables.PARTY_IDENTIFIER);
+                    payeePartyIdentifier = payeeObject.getString(KafkaVariables.PARTY_ID_IDENTIFIER);
 
                     payerPartyIdentifier = encryptData(payerPartyIdentifier);
                     payeePartyIdentifier = encryptData(payeePartyIdentifier);
 
-                    payerObject.put(KafkaVariables.PARTY_IDENTIFIER, payerPartyIdentifier);
-                    payeeObject.put(KafkaVariables.PARTY_IDENTIFIER, payeePartyIdentifier);
+                    payerObject.put(KafkaVariables.PARTY_ID_IDENTIFIER, payerPartyIdentifier);
+                    payeeObject.put(KafkaVariables.PARTY_ID_IDENTIFIER, payeePartyIdentifier);
 
                 } else if (payerValue instanceof JSONObject) {
                     JSONObject payerObject = (JSONObject) payerValue;

--- a/src/main/java/org/mifos/phee/kafkastreamer/importer/utils/AesUtil.java
+++ b/src/main/java/org/mifos/phee/kafkastreamer/importer/utils/AesUtil.java
@@ -72,7 +72,7 @@ public class AesUtil {
     }
     public static boolean checkForMaskingFields(JSONObject jsonObject, List<String> fieldsRequiredMasking) {
         for (String field : fieldsRequiredMasking) {
-            if (jsonObject.has(field)) {
+            if (!jsonObject.has(field)) {
                 return true;
             }
         }

--- a/src/main/java/org/mifos/phee/kafkastreamer/importer/utils/AesUtil.java
+++ b/src/main/java/org/mifos/phee/kafkastreamer/importer/utils/AesUtil.java
@@ -2,10 +2,14 @@ package org.mifos.phee.kafkastreamer.importer.utils;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
 import java.util.List;
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.apache.commons.codec.binary.Base64;
 import org.json.JSONObject;
@@ -57,10 +61,20 @@ public class AesUtil {
         return Base64.decodeBase64(base64EncodedString);
     }
 
-    // get instance of class [SecretKey] using the string format of the key
-    public static SecretKey getSecretKey(String key) {
+    public static SecretKey deriveKey(String key, byte[] salt, int iterationCount, int keyLength) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+        KeySpec spec = new PBEKeySpec(key.toCharArray(), salt, iterationCount, keyLength);
+        SecretKey tmp = factory.generateSecret(spec);
+        return new SecretKeySpec(tmp.getEncoded(), "AES");
+    }
+
+    public static SecretKey getSecretKey(String key) throws NoSuchAlgorithmException, InvalidKeySpecException {
         byte[] aesByte = base64Decode(key);
-        return new SecretKeySpec(aesByte, 0, aesByte.length,"AES");
+        int iterationCount = 10000;
+        int keyLength = 256;
+
+        SecretKey newKey = deriveKey(key, aesByte, iterationCount, keyLength);
+        return newKey;
     }
 
     // generates and returns the string encoded AES key

--- a/src/main/java/org/mifos/phee/kafkastreamer/importer/utils/AesUtil.java
+++ b/src/main/java/org/mifos/phee/kafkastreamer/importer/utils/AesUtil.java
@@ -66,7 +66,7 @@ public class AesUtil {
     // generates and returns the string encoded AES key
     public static String generateSecretKey() throws NoSuchAlgorithmException {
         KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
-        keyGenerator.init(256, new SecureRandom());
+        keyGenerator.init(128, new SecureRandom());
         SecretKey key = keyGenerator.generateKey();
         return base64Encode(key.getEncoded());
     }

--- a/src/main/java/org/mifos/phee/kafkastreamer/importer/utils/AesUtil.java
+++ b/src/main/java/org/mifos/phee/kafkastreamer/importer/utils/AesUtil.java
@@ -81,7 +81,7 @@ public class AesUtil {
     // generates and returns the string encoded AES key
     public static String generateSecretKey() throws NoSuchAlgorithmException {
         KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
-        keyGenerator.init(128, new SecureRandom());
+        keyGenerator.init(256, new SecureRandom());
         SecretKey key = keyGenerator.generateKey();
         return base64Encode(key.getEncoded());
     }

--- a/src/main/java/org/mifos/phee/kafkastreamer/importer/utils/AesUtil.java
+++ b/src/main/java/org/mifos/phee/kafkastreamer/importer/utils/AesUtil.java
@@ -60,7 +60,7 @@ public class AesUtil {
     // get instance of class [SecretKey] using the string format of the key
     public static SecretKey getSecretKey(String key) {
         byte[] aesByte = base64Decode(key);
-        return new SecretKeySpec(aesByte, "AES");
+        return new SecretKeySpec(aesByte, 0, aesByte.length,"AES");
     }
 
     // generates and returns the string encoded AES key

--- a/src/main/java/org/mifos/phee/kafkastreamer/importer/utils/AesUtil.java
+++ b/src/main/java/org/mifos/phee/kafkastreamer/importer/utils/AesUtil.java
@@ -68,10 +68,11 @@ public class AesUtil {
         return new SecretKeySpec(tmp.getEncoded(), "AES");
     }
 
+    // get instance of class [SecretKey] using the string format of the key
     public static SecretKey getSecretKey(String key) throws NoSuchAlgorithmException, InvalidKeySpecException {
         byte[] aesByte = base64Decode(key);
         int iterationCount = 10000;
-        int keyLength = 256;
+        int keyLength = 256; // adding key length
 
         SecretKey newKey = deriveKey(key, aesByte, iterationCount, keyLength);
         return newKey;


### PR DESCRIPTION
## Description

- Resolved masking for payer and payee object and array types
- Modified to generate secret key of length 256

https://fynarfin.atlassian.net/browse/PHEE-384?atlOrigin=eyJpIjoiY2IxYzQyOGFkY2EzNGUyMTk3N2IzNzdiMWQyZjcyMDEiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

 _(Ignore if these details are present on the associated JIRA ticket)_

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Design related bullet points or design document link related to this PR added in the description above.

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
